### PR TITLE
Rettede testfiler

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -5,7 +5,7 @@ description: "MedCom standard based on HL7 FHIR"
 show_downloads: true
 google_analytics:
 theme: jekyll-theme-minimal
-version: "Version 4.0.18"
+version: "Version 4.0.19"
 fhir_version: "FHIR®© R4"
 releasenote: https://github.com/medcomdk/dk-medcom-carecommunication/releases
 thisurl: https://medcomdk.github.io/dk-medcom-carecommunication/

--- a/docs/index.md
+++ b/docs/index.md
@@ -174,5 +174,5 @@ The table below includes examples of the mapping illustrating four different flo
 ### 3.4 Test protocol
 Test of the conversion service includes going through the testprotocol. In the test protocol the use cases and rules in the use case document are adressed, and it will be ensured that the mapping is performed correctly. 
   * [Test protocol in English (docx)](assets/ConversionService_Testprotocol.docx)
-    * [Test examples for the test protocol (zip)](assets/ConversionSerivice_TestExcamples_2025-05-07.zip). Test examples are updated 2025-05-07.
+    * [Test examples for the test protocol (zip)](assets/ConversionSerivice_TestExcamples_2025-05-15.zip). Test examples are updated 2025-05-15.
     * [Test examples without VANSenvelope (zip)](assets/ConvertionService_examples_without_VANSenvelope.zip). (Note: Not for use in test protocol, and not updated after 2025-01-30)


### PR DESCRIPTION
Jeg har rettet i: 
ConSer_Bin_DNHF --> EDI ændret til Edifact + EAN for afsender og modtager er ændret til lokationsnumre
ConSer_ACK_01 --> versionen er ændret fra 2.0.2 til 2.0.0 i envelopen
ConSer_ACK_02 --> versionen er ændret fra 2.0.2 til 2.0.0 i envelopen
ConSer_CC_01_reply --> versionen er ændret fra 4.0.2 til 4.0.0 i envelopen
ConSer_CC_02 --> versionen er ændret fra 4.0.2 til 4.0.0 i envelopen
ConSer_CC_02_multipleattachments --> versionen er ændret fra 4.0.2 til 4.0.0 i envelopen
ConSer_CC_03 --> versionen er ændret fra 4.0.2 til 4.0.0 i envelopen
ConSer_CC_03_attachment --> versionen er ændret fra 4.0.2 til 4.0.0 i envelopen + fjernet enter før XML deklaringen
ConSer_CC_04 --> versionen er ændret fra 4.0.2 til 4.0.0 i envelopen + tilføjet entity i provenance, da der var payloads som ikke var repræsenteret i en provenance + opdateret sizeinbytes i envelopen
ConSer_CC_05_reply_attachment --> versionen er ændret fra 4.0.2 til 4.0.0 i envelopen + tilføjet entity i provenance, da der var payloads som ikke var repræsenteret i en provenance + opdateret sizeinbytes i envelopen
ConSer_CC_06_forward --> versionen er ændret fra 4.0.2 til 4.0.0 i envelopen + tilføjet entity i provenance, da der var payloads som ikke var repræsenteret i en provenance + opdateret sizeinbytes i envelopen
ConSer_CC_tec_episodeofcare --> versionen er ændret fra 4.0.2 til 4.0.0 i envelopen + tilføjet en reference til encounter ressourcen i communication ressourcen + opdateret sizeinbytes i envelopen
ConSer_CC_tec_toomanyattachments --> versionen er ændret fra 4.0.2 til 4.0.0 i envelopen +  tilføjet entities i provenance, da der var payloads som ikke var repræsenteret i en provenance + + opdateret sizeinbytes i envelopen