### PR TITLE
removed text from the profile page

### DIFF
--- a/input/pagecontent/profiles.xml
+++ b/input/pagecontent/profiles.xml
@@ -2,7 +2,6 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hl7.org/fhir ../../input-cache/schemas-r5/fhir-single.xsd">
   
   <p>
-    The following profiles set the minimum expectations to record, search and fetch health data associated with a Patient:
   </p>
   <div>
     {% include list-profiles.xhtml %}


### PR DESCRIPTION
Removed the following text: "The following profiles set the minimum expectations to record, search and fetch health data associated with a Patient:" at this page: https://medcomfhir.dk/ig/carecommunication/profiles.html