### PR TITLE
constraint 11 and 12

### DIFF
--- a/input/fsh/MedComCareCommunicationMessage.fsh
+++ b/input/fsh/MedComCareCommunicationMessage.fsh
@@ -34,12 +34,12 @@ Expression: "entry.resource.ofType(Practitioner).name.exists()"
 Invariant: medcom-careCommunication-11
 Description: "If a specific sender exists, the organisation which the CareTeam or Practitioner is a part of shall be the same as the sender organisation in the MessageHeader resource."
 Severity: #error
-Expression: "Bundle.entry.resource.ofType(Communication).extension.value.reference.resolve().managingOrganization.reference = %resource.entry.resource.ofType(MessageHeader).sender.reference or Bundle.entry.resource.ofType(Communication).extension.value.reference.resolve().organization.reference = %resource.entry.resource.ofType(MessageHeader).sender.reference or Bundle.entry.resource.ofType(Communication).extension.exists().not()"
+Expression: "Bundle.entry.resource.ofType(Communication).extension.value.reference.resolve().managingOrganization.reference.resolve() = %resource.entry.resource.ofType(MessageHeader).sender.reference.resolve() or Bundle.entry.resource.ofType(Communication).extension.value.reference.resolve().organization.reference.resolve() = %resource.entry.resource.ofType(MessageHeader).sender.reference.resolve() or Bundle.entry.resource.ofType(Communication).extension.exists().not()"
 
 Invariant: medcom-careCommunication-12
 Description: "If a specific recipient exists, the organisation which the CareTeam or Practitioner is a part of shall be the same as the receiver organisation in the MessageHeader resource."
 Severity: #error
-Expression: "Bundle.entry.resource.ofType(Communication).recipient.reference.resolve().managingOrganization.reference = %resource.entry.resource.ofType(MessageHeader).destination.receiver.reference or Bundle.entry.resource.ofType(Communication).recipient.reference.resolve().organization.reference = %resource.entry.resource.ofType(MessageHeader).destination.receiver.reference or Bundle.entry.resource.ofType(Communication).recipient.exists().not()"
+Expression: "Bundle.entry.resource.ofType(Communication).recipient.reference.resolve().managingOrganization.reference.resolve() = %resource.entry.resource.ofType(MessageHeader).destination.receiver.reference.resolve() or Bundle.entry.resource.ofType(Communication).recipient.reference.resolve().organization.reference.resolve() = %resource.entry.resource.ofType(MessageHeader).destination.receiver.reference.resolve() or undle.entry.resource.ofType(Communication).recipient.exists().not()"
 
 Invariant: medcom-careCommunication-13
 Description: "All PractitionerRole resources shall have a reference to an instance of a Practitioner resource."


### PR DESCRIPTION
In this pull request, I have updated both constraint medcom-careCommunication-11 and medcom-careCommunication-12 to use .resolve().

The reason for using .resolve() in both constraints is that the sender and recipient are specified as Reference elements—either via an extension (for the sender) or directly (for the recipient). In order to compare the organization that a Practitioner or CareTeam is part of with the corresponding sender or receiver organization in the MessageHeader, it is necessary to resolve the reference to access the full resource and its internal fields (such as organization.reference or managingOrganization.reference).

Please test this in the fhirpath tester to ensure it works intentionally.