### PR TITLE
added a text stating that: If the previous message is an EDIFACT or O…

### DIFF
--- a/input/fsh/MedComCareCommunicationProvenance.fsh
+++ b/input/fsh/MedComCareCommunicationProvenance.fsh
@@ -4,6 +4,7 @@ Id: medcom-careCommunication-provenance
 Description: "Provenance information about the current and preceeding message."
 * target only Reference(MedComCareCommunicationMessageHeader)
 * activity from $CareCommunicationActivities
+* activity ^short = "If the previous message is an EDIFACT or OIOXML message, the activity code must be reply-message"
 * entity 1..* 
 * entity ^slicing.discriminator.type = #value
 * entity ^slicing.discriminator.path = "role"


### PR DESCRIPTION
This pull request updates the descriptive text related to activity codes:

"If the previous message is an EDIFACT or OIOXML message, the activity code must be reply-message."

