### PR TITLE
OLW use pipe for messagedefinition

### DIFF
--- a/input/fsh/1st-message.fsh
+++ b/input/fsh/1st-message.fsh
@@ -35,7 +35,7 @@ Usage: #example
 * sender = Reference(b581c63c-181f-46f6-990d-b9942c576724)
 * source.endpoint = "https://sor2.sum.dsdn.dk/#id=265161000016000"
 * focus = Reference(94e65db8-2f0c-4a2c-a7c9-06a160d59a12)
-* definition = "http://medcomfhir.dk/ig/carecommunication/medcom-careCommunication-message-definition|4.0.0"
+* definition = "http://medcomfhir.dk/ig/messagedefinitions/MessageDefinition/MedComCareCommunicationMessageDefinition|5.0"
 
 
 // CareCommunication new example

--- a/input/fsh/2nd-message.fsh
+++ b/input/fsh/2nd-message.fsh
@@ -43,8 +43,7 @@ Usage: #example
 * sender = Reference(487ac745-fd11-4879-9b59-c08c7d47260e)
 * source.endpoint = "https://sor2.sum.dsdn.dk/#id=953741000016009"
 * focus = Reference(4c712bdc-1558-4125-a854-fa8b3a11f6ed)
-* definition = "http://medcomfhir.dk/ig/carecommunication/medcom-careCommunication-message-definition|4.0.0"
-
+* definition = "http://medcomfhir.dk/ig/messagedefinitions/MessageDefinition/MedComCareCommunicationMessageDefinition|5.0"
 
 Instance: 30c0f779-783f-46b2-b38f-faebd2bedb3f
 InstanceOf: MedComCareCommunicationProvenance

--- a/input/fsh/3rd-message.fsh
+++ b/input/fsh/3rd-message.fsh
@@ -43,8 +43,7 @@ Usage: #example
 * sender = Reference(82210440-6826-44fc-9fc8-2a29bab6a5c2)
 * source.endpoint = "https://sor2.sum.dsdn.dk/#id=265161000016000"
 * focus = Reference(d2b79da8-acda-4985-a8ad-5ed7ec9a2800)
-* definition = "http://medcomfhir.dk/ig/carecommunication/medcom-careCommunication-message-definition|4.0.0"
-
+* definition = "http://medcomfhir.dk/ig/messagedefinitions/MessageDefinition/MedComCareCommunicationMessageDefinition|5.0"
 
 
 

--- a/input/fsh/4th-message.fsh
+++ b/input/fsh/4th-message.fsh
@@ -60,7 +60,7 @@ Description: "4th message - Example of a MessageHeader in a forward CareCommunic
 * sender = Reference(f20f31cd-5dd2-4a80-ab00-97f7109864a7)
 * source.endpoint = "https://sor2.sum.dsdn.dk/#id=265161000016000"
 * focus = Reference(5485bde0-8246-4f46-b1a1-1f14e0a7a856)
-* definition = "http://medcomfhir.dk/ig/carecommunication/medcom-careCommunication-message-definition|4.0.0"
+* definition = "http://medcomfhir.dk/ig/messagedefinitions/MessageDefinition/MedComCareCommunicationMessageDefinition|5.0"
 
 Instance: f98ed410-54fe-11ed-bdc3-0242ac120002
 InstanceOf: MedComMessagingOrganization 

--- a/input/fsh/5th-message.fsh
+++ b/input/fsh/5th-message.fsh
@@ -68,7 +68,7 @@ Usage: #example
 * sender = Reference(f98ed410-54fe-11ed-bdc3-0242ac120002)
 * source.endpoint = "https://sor2.sum.dsdn.dk/#id=1042981000016003"
 * focus = Reference(d148fa55-3201-4a18-a7b0-bce67bf597a6)
-* definition = "http://medcomfhir.dk/ig/carecommunication/medcom-careCommunication-message-definition|4.0.0"
+* definition = "http://medcomfhir.dk/ig/messagedefinitions/MessageDefinition/MedComCareCommunicationMessageDefinition|5.0"
 
 // CareCommunication reply example
 Instance: d148fa55-3201-4a18-a7b0-bce67bf597a6

--- a/input/fsh/6-replacementCPR.fsh
+++ b/input/fsh/6-replacementCPR.fsh
@@ -35,7 +35,7 @@ Usage: #example
 * sender = Reference(0ece868c-6a72-4aa3-8a96-2d985ab630c7)
 * source.endpoint = "https://sor2.sum.dsdn.dk/#id=265161000016000"
 * focus = Reference(d8434eb5-8286-48f8-a590-4a27175ed82f)
-* definition = "http://medcomfhir.dk/ig/carecommunication/medcom-careCommunication-message-definition|4.0.0"
+* definition = "http://medcomfhir.dk/ig/messagedefinitions/MessageDefinition/MedComCareCommunicationMessageDefinition|5.0"
 
 
 // CareCommunication new example

--- a/input/fsh/7-replyOIOXML copy.fsh
+++ b/input/fsh/7-replyOIOXML copy.fsh
@@ -38,7 +38,7 @@ Usage: #example
 * sender = Reference(e17d03b8-e7fd-4654-bc9c-cb2eb5dda71f)
 * source.endpoint = "https://sor2.sum.dsdn.dk/#id=265161000016000"
 * focus = Reference(f54efd18-5520-11ed-bdc3-0242ac120002)
-* definition = "http://medcomfhir.dk/ig/carecommunication/medcom-careCommunication-message-definition|4.0.0"
+* definition = "http://medcomfhir.dk/ig/messagedefinitions/MessageDefinition/MedComCareCommunicationMessageDefinition|5.0"
 
 Instance: 6de0806d-7050-4db8-8003-0c72aee52948
 InstanceOf: MedComCareCommunicationProvenance

--- a/input/fsh/8-AllContent.fsh
+++ b/input/fsh/8-AllContent.fsh
@@ -43,7 +43,7 @@ Usage: #example
 * sender = Reference(c39b114b-a9c1-46bb-ac30-e3ce71f28c3a)
 * source.endpoint = "https://sor2.sum.dsdn.dk/#id=265161000016000"
 * focus = Reference(c34e8284-b353-468f-a2ea-f6ef6330292c)
-* definition = "http://medcomfhir.dk/ig/carecommunication/medcom-careCommunication-message-definition|4.0.0"
+* definition = "http://medcomfhir.dk/ig/messagedefinitions/MessageDefinition/MedComCareCommunicationMessageDefinition|5.0"
 
 // CareCommunication example - new message w. journalnote
 Instance: 790daa1e-bf50-4ee0-af8c-31c493e272bb

--- a/input/fsh/MedComCareCommunicationHeader.fsh
+++ b/input/fsh/MedComCareCommunicationHeader.fsh
@@ -26,8 +26,8 @@ Description: "Message header for CareCommunication message"
 
 Invariant: medcom-carecommunication-definition-url
 Description: "SHALL reference a MedCom CareCommunication MessageDefinition whose canonical URL starts with
-http://medcomfhir.dk/ig/messagedefinitions/MessageDefinition/MedComCareCommunicationMessageDefinition5. — that is, any version 5.x of the message definition. The current minor version the sender uses must be added in the end of the definition."
-Expression: "matches('^http://medcomfhir.dk/ig/messagedefinitions/MessageDefinition/MedComCareCommunicationMessageDefinition5[.][0-9]{1,2}$')"
+http://medcomfhir.dk/ig/messagedefinitions/MessageDefinition/MedComCareCommunicationMessageDefinition|5. — that is, any version 5.x of the message definition. The current minor version the sender uses must be added in the end of the definition."
+Expression: "matches('^http://medcomfhir.dk/ig/messagedefinitions/MessageDefinition/MedComCareCommunicationMessageDefinition|5[.][0-9]{1,2}$')"
 Severity: #error
 
 

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -19,7 +19,7 @@ dependencies:
   medcom.fhir.dk.core: 2.4.0
   medcom.fhir.dk.messaging: 2.2.2
   medcom.fhir.dk.terminology: 1.7.0
-  medcom.fhir.dk.messagedefinitions: 1.0.0-trial-use 
+  medcom.fhir.dk.messagedefinitions: 1.0.1-trial-use 
   
 menu:
   Table of Contents: toc.html


### PR DESCRIPTION
Hey @RikkeVestesen,
I've changed the MessageDefinitions IG so that we can use a pipe | symbol instead. I therefore went ahead and changed the IG in this PR.
I've done the following:
- Updated the MessageDefinitions dependency to 1.0.1
- The invariant on the profile has been changed.
- I noticed that actually none of the examples used the correct definition, it still pointed to the old one. So I just went ahead and fixed these as well, which should lessen the amount of errors in the QA report hopefully.