### PR TITLE
Fix definition constraint

### DIFF
--- a/input/fsh/MedComCareCommunicationHeader.fsh
+++ b/input/fsh/MedComCareCommunicationHeader.fsh
@@ -15,7 +15,7 @@ Description: "Message header for CareCommunication message"
 Invariant: medcom-carecommunication-definition-url
 Description: "SHALL reference a MedCom CareCommunication MessageDefinition whose canonical URL starts with
 http://medcomfhir.dk/ig/messagedefinitions/MessageDefinition/MedComCareCommunicationMessageDefinition|5. — that is, any version 5.x of the message definition. The current minor version the sender uses must be added in the end of the definition."
-Expression: "matches('^http://medcomfhir.dk/ig/messagedefinitions/MessageDefinition/MedComCareCommunicationMessageDefinition|5[.][0-9]{1,2}$')"
+Expression: "matches('^http://medcomfhir.dk/ig/messagedefinitions/MessageDefinition/MedComCareCommunicationMessageDefinition\\|5[.][0-9]{1,2}$')"
 Severity: #error
 
 /* // CareCommunication Cancel example


### PR DESCRIPTION
I stumbled upon an error. With the current implementation it does not care about the major version due to a regex misconfiguration. So currently it accepts 1.x, 2.x, 3.x etc. even though it should be 5.x 